### PR TITLE
Bugfix: error reporting reports wrong line

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -92,7 +92,15 @@ class FeatureContext extends BehatContext
     }
 
     /**
-     * @Then /^I get (?!an error|the error)(.*)$/
+     * @When /^I parse$/
+     */
+    public function iParseBlock(PyStringNode $string)
+    {
+        $this->iParse($string->__toString());
+    }
+
+    /**
+     * @Then /^I get (?!no errors|an error|the error)(.*)$/
      */
     public function iGet($result)
     {
@@ -101,6 +109,16 @@ class FeatureContext extends BehatContext
         }
 
         assertSame(json_decode($result), $this->result);
+    }
+
+    /**
+     * @Then /^I get no errors$/
+     */
+    public function iGetNoErrors()
+    {
+        if ($this->error !== null) {
+            throw $this->error;
+        }
     }
 
     /**

--- a/features/errors.feature
+++ b/features/errors.feature
@@ -8,13 +8,13 @@ Feature: Parser errors
     """
     grammar SomeErrorTest
     {
-      start Test = $("(" "1" (_ "+" _ "1")* ")");
+      start Test = "(" "1" (_ "+" _ "1")* ")";
       _ = " "*;
     }
     """
 
     When I parse "(1 + 1 + 1)"
-    Then I get "(1 + 1 + 1)"
+    Then I get no errors
 
     When I parse "(1 + 1 + )"
     Then I get the error "Syntax error, expecting " ", "1" on line 1"
@@ -24,13 +24,13 @@ Feature: Parser errors
     """
     grammar UsefulErrorTest
     {
-      start Test = $("(" ^ "1" (_ "+" ^ _ "1")* ")");
+      start Test = "(" ^ "1" (_ "+" ^ _ "1")* ")";
       _ = " "*;
     }
     """
 
     When I parse "(1 + 1 + 1)"
-    Then I get "(1 + 1 + 1)"
+    Then I get no errors
 
     When I parse "(1 + 1 + )"
     Then I get the error "Syntax error, expecting "1" on line 1"
@@ -43,10 +43,48 @@ Feature: Parser errors
     """
     grammar NamedRuleTest
     {
-      start Test "expression" = $("(" ^ "1" (_ "+" ^ _ "1")* ")");
+      start Test "expression" = "(" ^ "1" (_ "+" ^ _ "1")* ")";
       _ = " "*;
     }
     """
 
     When I parse ""
     Then I get the error "Syntax error, expecting "(", expression on line 1"
+
+  Scenario: A grammar which accepts part of the file gives us useful line numbers
+    Given I have a grammar containing:
+    """
+    grammar LineNumberTest
+    {
+        start Test = Operation*;
+        Operation = "ADD" " " Register ", " Register ", " Register "\n"
+                  / "PUSH" " " Register ", " Value "\n"
+                  / "MOV" " " Register ", " Register "\n"
+                  / "DO" "\n" Operation* "LOOP" "\n";
+        Register = [a-z];
+        Value = [0-9];
+    }
+    """
+
+    When I parse
+    """
+    PUSH a, 1
+    PUSH b, 1
+    DO
+    ADD a, b, c
+    MOV c, a
+    LOOP
+
+    """
+    Then I get no errors
+
+    When I parse
+    """
+    PUSH a, 1
+    PUSH b, 1
+    DO
+    ADD a, b, c
+    MOV c, a
+
+    """
+    Then I get the error "Syntax error, expecting "ADD", "PUSH", "MOV", "DO", Operation, "LOOP" on line 6"

--- a/spec/PHPeg/Generator/ToClassVisitorSpec.php
+++ b/spec/PHPeg/Generator/ToClassVisitorSpec.php
@@ -230,7 +230,13 @@ class FooFile
 
     private function line()
     {
-        return count(explode("\\n", substr(\$this->string, 0, \$this->position)));
+        if (!empty(\$this->errors)) {
+            \$positions = array_keys(\$this->errors);
+        } else {
+            \$positions = array_keys(\$this->warnings);
+        }
+
+        return count(explode("\\n", substr(\$this->string, 0, max(\$positions))));
     }
 
     private function rest()
@@ -272,7 +278,7 @@ class FooFile
 
         \$_success = \$this->parseFoo();
 
-        if (\$this->position < strlen(\$this->string)) {
+        if (\$_success && \$this->position < strlen(\$this->string)) {
             \$_success = false;
 
             \$this->report(\$this->position, "end of file");

--- a/spec/PHPeg/Generator/ToClassVisitorSpec.php
+++ b/spec/PHPeg/Generator/ToClassVisitorSpec.php
@@ -272,12 +272,14 @@ class FooFile
 
         \$_success = \$this->parseFoo();
 
-        if (!\$_success) {
-            throw new \InvalidArgumentException("Syntax error, expecting {\$this->expecting()} on line {\$this->line()}");
+        if (\$this->position < strlen(\$this->string)) {
+            \$_success = false;
+
+            \$this->report(\$this->position, "end of file");
         }
 
-        if (\$this->position < strlen(\$this->string)) {
-            throw new \InvalidArgumentException("Syntax error, unexpected {\$this->rest()} on line {\$this->line()}");
+        if (!\$_success) {
+            throw new \InvalidArgumentException("Syntax error, expecting {\$this->expecting()} on line {\$this->line()}");
         }
 
         return \$this->value;

--- a/spec/PHPeg/Grammar/PegFileSpec.php
+++ b/spec/PHPeg/Grammar/PegFileSpec.php
@@ -284,7 +284,7 @@ class PegFileSpec extends ObjectBehavior
             ->duringParse('grammar TestFile { start File = foo:; }');
 
         $this
-            ->shouldThrow(new \InvalidArgumentException('Syntax error, unexpected "use" on line 1'))
+            ->shouldThrow(new \InvalidArgumentException('Syntax error, expecting end of file on line 1'))
             ->duringParse('grammar TestFile { start File = "foo" / "bar"; } use');
     }
 }

--- a/src/PHPeg/Generator/ToClassVisitor.php
+++ b/src/PHPeg/Generator/ToClassVisitor.php
@@ -267,12 +267,14 @@ EOS;
 
         \$_success = \$this->parse{$node->getStartSymbol()}();
 
-        if (!\$_success) {
-            throw new \InvalidArgumentException("Syntax error, expecting {\$this->expecting()} on line {\$this->line()}");
+        if (\$this->position < strlen(\$this->string)) {
+            \$_success = false;
+
+            \$this->report(\$this->position, "end of file");
         }
 
-        if (\$this->position < strlen(\$this->string)) {
-            throw new \InvalidArgumentException("Syntax error, unexpected {\$this->rest()} on line {\$this->line()}");
+        if (!\$_success) {
+            throw new \InvalidArgumentException("Syntax error, expecting {\$this->expecting()} on line {\$this->line()}");
         }
 
         return \$this->value;

--- a/src/PHPeg/Generator/ToClassVisitor.php
+++ b/src/PHPeg/Generator/ToClassVisitor.php
@@ -225,7 +225,13 @@ EOS;
 
     private function line()
     {
-        return count(explode("\\n", substr(\$this->string, 0, \$this->position)));
+        if (!empty(\$this->errors)) {
+            \$positions = array_keys(\$this->errors);
+        } else {
+            \$positions = array_keys(\$this->warnings);
+        }
+
+        return count(explode("\\n", substr(\$this->string, 0, max(\$positions))));
     }
 
     private function rest()
@@ -267,7 +273,7 @@ EOS;
 
         \$_success = \$this->parse{$node->getStartSymbol()}();
 
-        if (\$this->position < strlen(\$this->string)) {
+        if (\$_success && \$this->position < strlen(\$this->string)) {
             \$_success = false;
 
             \$this->report(\$this->position, "end of file");

--- a/src/PHPeg/Grammar/PegFile.php
+++ b/src/PHPeg/Grammar/PegFile.php
@@ -3541,12 +3541,14 @@ class PegFile
 
         $_success = $this->parsePegFile();
 
-        if (!$_success) {
-            throw new \InvalidArgumentException("Syntax error, expecting {$this->expecting()} on line {$this->line()}");
+        if ($this->position < strlen($this->string)) {
+            $_success = false;
+
+            $this->report($this->position, "end of file");
         }
 
-        if ($this->position < strlen($this->string)) {
-            throw new \InvalidArgumentException("Syntax error, unexpected {$this->rest()} on line {$this->line()}");
+        if (!$_success) {
+            throw new \InvalidArgumentException("Syntax error, expecting {$this->expecting()} on line {$this->line()}");
         }
 
         return $this->value;

--- a/src/PHPeg/Grammar/PegFile.php
+++ b/src/PHPeg/Grammar/PegFile.php
@@ -3499,7 +3499,13 @@ class PegFile
 
     private function line()
     {
-        return count(explode("\n", substr($this->string, 0, $this->position)));
+        if (!empty($this->errors)) {
+            $positions = array_keys($this->errors);
+        } else {
+            $positions = array_keys($this->warnings);
+        }
+
+        return count(explode("\n", substr($this->string, 0, max($positions))));
     }
 
     private function rest()
@@ -3541,7 +3547,7 @@ class PegFile
 
         $_success = $this->parsePegFile();
 
-        if ($this->position < strlen($this->string)) {
+        if ($_success && $this->position < strlen($this->string)) {
             $_success = false;
 
             $this->report($this->position, "end of file");


### PR DESCRIPTION
I also decided that unexpected trailing content should be handled just like any other error.
