### PR TITLE
Fix PHP8 Fatal error: Array and string offset access syntax with curl…

### DIFF
--- a/src/PHPeg/Console/BenchmarkCommand.php
+++ b/src/PHPeg/Console/BenchmarkCommand.php
@@ -24,7 +24,7 @@ class BenchmarkCommand extends Command
 
         $precision = 3 - strlen(floor($value));
 
-        return round($value, $precision) . $units{$order};
+        return round($value, $precision) . $units[$order];
     }
 
     protected function configure()
@@ -75,4 +75,4 @@ class BenchmarkCommand extends Command
         $output->writeln("Average time: {$avg}ms");
         $output->writeln("Runs per second: {$rps}");
     }
-} 
+}


### PR DESCRIPTION
…y braces is no longer supported

To make it run on php 8..